### PR TITLE
feat: Add Metallurgie regionales

### DIFF
--- a/data/KALICONT000005635842-1007.json
+++ b/data/KALICONT000005635842-1007.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1007",
+    "nature": "IDCC",
+    "num": 1007,
+    "shortTitle": "Convention collective locale d'arrondissement des industries métallurgiques, mécaniques, connexes et similaires de la région de Thiers (Puy-de-Dôme)",
+    "title": "Convention collective locale d'arrondissement des industries métallurgiques, mécaniques, connexes et similaires de la région de Thiers (Puy-de-Dôme)"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1059.json
+++ b/data/KALICONT000005635842-1059.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1059",
+    "nature": "IDCC",
+    "num": 1059,
+    "shortTitle": "Convention collective régionale des industries métallurgiques, électriques, électroniques et connexes de MidiPyrénées (Ariège, Aveyron, Gers, Haute-Garonne, Tarn, Tarn-et-Garonne, Lot, Aude convention du 1er avril 1980)",
+    "title": "Convention collective régionale des industries métallurgiques, électriques, électroniques et connexes de MidiPyrénées (Ariège, Aveyron, Gers, Haute-Garonne, Tarn, Tarn-et-Garonne, Lot, Aude convention du 1er avril 1980)"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1159.json
+++ b/data/KALICONT000005635842-1159.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1159",
+    "nature": "IDCC",
+    "num": 1159,
+    "shortTitle": "Convention collective départementale de la métallurgie de la Nièvre",
+    "title": "Convention collective départementale de la métallurgie de la Nièvre"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1164.json
+++ b/data/KALICONT000005635842-1164.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1164",
+    "nature": "IDCC",
+    "num": 1164,
+    "shortTitle": "Convention collective locale des industries métallurgiques et annexes de la région de Vimeu (Somme)",
+    "title": "Convention collective locale des industries métallurgiques et annexes de la région de Vimeu (Somme)"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1274.json
+++ b/data/KALICONT000005635842-1274.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1274",
+    "nature": "IDCC",
+    "num": 1274,
+    "shortTitle": "Convention collective départementale des industries métallurgiques de la Corrèze",
+    "title": "Convention collective départementale des industries métallurgiques de la Corrèze"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1315.json
+++ b/data/KALICONT000005635842-1315.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1315",
+    "nature": "IDCC",
+    "num": 1315,
+    "shortTitle": "Convention collective régionale des industries métallurgiques, mécaniques et connexes de la Haute-Marne et de la Meuse",
+    "title": "Convention collective régionale des industries métallurgiques, mécaniques et connexes de la Haute-Marne et de la Meuse"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1353.json
+++ b/data/KALICONT000005635842-1353.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1353",
+    "nature": "IDCC",
+    "num": 1353,
+    "shortTitle": "Convention collective départementale des industries métallurgiques et connexes de la Dordogne",
+    "title": "Convention collective départementale des industries métallurgiques et connexes de la Dordogne"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1365.json
+++ b/data/KALICONT000005635842-1365.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1365",
+    "nature": "IDCC",
+    "num": 1365,
+    "shortTitle": "Convention collective départementale de travail des industries de transformation des métaux de Meurthe-et-Moselle (métallurgie)",
+    "title": "Convention collective départementale de travail des industries de transformation des métaux de Meurthe-et-Moselle (métallurgie)"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1369.json
+++ b/data/KALICONT000005635842-1369.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1369",
+    "nature": "IDCC",
+    "num": 1369,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, électriques, électroniques et connexes de Loire-Atlantique",
+    "title": "Convention collective départementale des industries métallurgiques, électriques, électroniques et connexes de Loire-Atlantique"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1375.json
+++ b/data/KALICONT000005635842-1375.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1375",
+    "nature": "IDCC",
+    "num": 1375,
+    "shortTitle": "Convention collective Métallurgie Doubs",
+    "title": "Convention collective Métallurgie Doubs"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1387.json
+++ b/data/KALICONT000005635842-1387.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1387",
+    "nature": "IDCC",
+    "num": 1387,
+    "shortTitle": "Convention collective locale des mensuels des industries métallurgiques des Flandres",
+    "title": "Convention collective locale des mensuels des industries métallurgiques des Flandres"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1472.json
+++ b/data/KALICONT000005635842-1472.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1472",
+    "nature": "IDCC",
+    "num": 1472,
+    "shortTitle": "Convention collective départementale des industries métallurgiques du Pas-de-Calais",
+    "title": "Convention collective départementale des industries métallurgiques du Pas-de-Calais"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1525.json
+++ b/data/KALICONT000005635842-1525.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1525",
+    "nature": "IDCC",
+    "num": 1525,
+    "shortTitle": "Convention collective locale de la métallurgie de la région dunkerquoise",
+    "title": "Convention collective locale de la métallurgie de la région dunkerquoise"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1560.json
+++ b/data/KALICONT000005635842-1560.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1560",
+    "nature": "IDCC",
+    "num": 1560,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, électriques et connexes des AlpesMaritimes",
+    "title": "Convention collective départementale des industries métallurgiques, électriques et connexes des AlpesMaritimes"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1564.json
+++ b/data/KALICONT000005635842-1564.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1564",
+    "nature": "IDCC",
+    "num": 1564,
+    "shortTitle": "Convention collective départementale des industries de la métallurgie de Saône-et-Loire",
+    "title": "Convention collective départementale des industries de la métallurgie de Saône-et-Loire"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1572.json
+++ b/data/KALICONT000005635842-1572.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1572",
+    "nature": "IDCC",
+    "num": 1572,
+    "shortTitle": "Convention collective départementale de la métallurgie de la Charente",
+    "title": "Convention collective départementale de la métallurgie de la Charente"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1576.json
+++ b/data/KALICONT000005635842-1576.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1576",
+    "nature": "IDCC",
+    "num": 1576,
+    "shortTitle": "Convention collective départementale de travail des industries métallurgiques, mécaniques, électriques, électroniques, connexes et similaires du département du Cher",
+    "title": "Convention collective départementale de travail des industries métallurgiques, mécaniques, électriques, électroniques, connexes et similaires du département du Cher"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1577.json
+++ b/data/KALICONT000005635842-1577.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1577",
+    "nature": "IDCC",
+    "num": 1577,
+    "shortTitle": "Convention collective régionale des industries métallurgiques, électroniques et connexes de l'Hérault, de l'Aude et des Pyrénées-Orientales",
+    "title": "Convention collective régionale des industries métallurgiques, électroniques et connexes de l'Hérault, de l'Aude et des Pyrénées-Orientales"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1578.json
+++ b/data/KALICONT000005635842-1578.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1578",
+    "nature": "IDCC",
+    "num": 1578,
+    "shortTitle": "Convention collective départementale de la métallurgie de la Loire et de l'arrondissement d'Yssingeaux",
+    "title": "Convention collective départementale de la métallurgie de la Loire et de l'arrondissement d'Yssingeaux"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1592.json
+++ b/data/KALICONT000005635842-1592.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1592",
+    "nature": "IDCC",
+    "num": 1592,
+    "shortTitle": "Convention collective locale de la métallurgie du Valenciennois et du Cambrésis",
+    "title": "Convention collective locale de la métallurgie du Valenciennois et du Cambrésis"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1604.json
+++ b/data/KALICONT000005635842-1604.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1604",
+    "nature": "IDCC",
+    "num": 1604,
+    "shortTitle": "Convention collective métallurgie Rouen Dieppe (Seine-Maritime)",
+    "title": "Convention collective métallurgie Rouen Dieppe (Seine-Maritime)"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1626.json
+++ b/data/KALICONT000005635842-1626.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1626",
+    "nature": "IDCC",
+    "num": 1626,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, électrocéramiques et connexes des Hautes-Pyrénées",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, électrocéramiques et connexes des Hautes-Pyrénées"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1627.json
+++ b/data/KALICONT000005635842-1627.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1627",
+    "nature": "IDCC",
+    "num": 1627,
+    "shortTitle": "Convention collective départementale du travail des industries de la métallurgie et des constructions mécaniques de Clermont-Ferrand et du Puy-de-Dôme",
+    "title": "Convention collective départementale du travail des industries de la métallurgie et des constructions mécaniques de Clermont-Ferrand et du Puy-de-Dôme"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1628.json
+++ b/data/KALICONT000005635842-1628.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1628",
+    "nature": "IDCC",
+    "num": 1628,
+    "shortTitle": "Convention collective départementale de la métallurgie des Deux-Sèvres",
+    "title": "Convention collective départementale de la métallurgie des Deux-Sèvres"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1634.json
+++ b/data/KALICONT000005635842-1634.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1634",
+    "nature": "IDCC",
+    "num": 1634,
+    "shortTitle": "Convention collective départementale de la métallurgie des Côtes-d'Armor",
+    "title": "Convention collective départementale de la métallurgie des Côtes-d'Armor"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1732.json
+++ b/data/KALICONT000005635842-1732.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1732",
+    "nature": "IDCC",
+    "num": 1732,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques et connexes de l'Yonne",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques et connexes de l'Yonne"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1809.json
+++ b/data/KALICONT000005635842-1809.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1809",
+    "nature": "IDCC",
+    "num": 1809,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, similaires et connexes du Jura",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques, similaires et connexes du Jura"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1813.json
+++ b/data/KALICONT000005635842-1813.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1813",
+    "nature": "IDCC",
+    "num": 1813,
+    "shortTitle": "Convention collective locale de travail des industries de la transformation des métaux de la région de Maubeuge",
+    "title": "Convention collective locale de travail des industries de la transformation des métaux de la région de Maubeuge"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1867.json
+++ b/data/KALICONT000005635842-1867.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1867",
+    "nature": "IDCC",
+    "num": 1867,
+    "shortTitle": "Convention collective régionale de la métallurgie de la Drôme-Ardèche",
+    "title": "Convention collective régionale de la métallurgie de la Drôme-Ardèche"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1885.json
+++ b/data/KALICONT000005635842-1885.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1885",
+    "nature": "IDCC",
+    "num": 1885,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques et connexes du département de la Côte-d'Or",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques et connexes du département de la Côte-d'Or"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1902.json
+++ b/data/KALICONT000005635842-1902.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1902",
+    "nature": "IDCC",
+    "num": 1902,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, électroniques connexes et similaires du Maine-et-Loire",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, électroniques connexes et similaires du Maine-et-Loire"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1912.json
+++ b/data/KALICONT000005635842-1912.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1912",
+    "nature": "IDCC",
+    "num": 1912,
+    "shortTitle": "Convention collective départementale des industries de la métallurgie du Haut-Rhin",
+    "title": "Convention collective départementale des industries de la métallurgie du Haut-Rhin"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1960.json
+++ b/data/KALICONT000005635842-1960.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1960",
+    "nature": "IDCC",
+    "num": 1960,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques et connexes du Lot-et-Garonne",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques et connexes du Lot-et-Garonne"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1966.json
+++ b/data/KALICONT000005635842-1966.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1966",
+    "nature": "IDCC",
+    "num": 1966,
+    "shortTitle": "Convention collective départementale des industries métallurgiques du Loiret",
+    "title": "Convention collective départementale des industries métallurgiques du Loiret"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-1967.json
+++ b/data/KALICONT000005635842-1967.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-1967",
+    "nature": "IDCC",
+    "num": 1967,
+    "shortTitle": "Convention collective départementale de l'industrie des métaux du Bas-Rhin",
+    "title": "Convention collective départementale de l'industrie des métaux du Bas-Rhin"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-2003.json
+++ b/data/KALICONT000005635842-2003.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-2003",
+    "nature": "IDCC",
+    "num": 2003,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, électriques, électroniques et connexes du département des Vosges",
+    "title": "Convention collective départementale des industries métallurgiques, électriques, électroniques et connexes du département des Vosges"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-2126.json
+++ b/data/KALICONT000005635842-2126.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-2126",
+    "nature": "IDCC",
+    "num": 2126,
+    "shortTitle": "Convention collective régionale de la métallurgie du Gard et de la Lozère",
+    "title": "Convention collective régionale de la métallurgie du Gard et de la Lozère"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-2221.json
+++ b/data/KALICONT000005635842-2221.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-2221",
+    "nature": "IDCC",
+    "num": 2221,
+    "shortTitle": "Convention collective régionale des mensuels des industries des métaux de l'Isère et des Hautes-Alpes",
+    "title": "Convention collective régionale des mensuels des industries des métaux de l'Isère et des Hautes-Alpes"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-2266.json
+++ b/data/KALICONT000005635842-2266.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-2266",
+    "nature": "IDCC",
+    "num": 2266,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de la Mayenne",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de la Mayenne"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-2294.json
+++ b/data/KALICONT000005635842-2294.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-2294",
+    "nature": "IDCC",
+    "num": 2294,
+    "shortTitle": "Convention collective départementale des industries et métiers de la métallurgie de l'Aube",
+    "title": "Convention collective départementale des industries et métiers de la métallurgie de l'Aube"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-2489.json
+++ b/data/KALICONT000005635842-2489.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-2489",
+    "nature": "IDCC",
+    "num": 2489,
+    "shortTitle": "Convention collective départementale des industries métallurgiques et assimilées de la Vendée",
+    "title": "Convention collective départementale des industries métallurgiques et assimilées de la Vendée"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-2615.json
+++ b/data/KALICONT000005635842-2615.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-2615",
+    "nature": "IDCC",
+    "num": 2615,
+    "shortTitle": "Convention collective régionale de la métallurgie des Pyrénées-Atlantiques et du Seignanx",
+    "title": "Convention collective régionale de la métallurgie des Pyrénées-Atlantiques et du Seignanx"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-2630.json
+++ b/data/KALICONT000005635842-2630.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-2630",
+    "nature": "IDCC",
+    "num": 2630,
+    "shortTitle": "Convention collective régionale des industries métallurgiques des Bouches-du-Rhône et Alpes-de-HauteProvence",
+    "title": "Convention collective régionale des industries métallurgiques des Bouches-du-Rhône et Alpes-de-HauteProvence"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-2700.json
+++ b/data/KALICONT000005635842-2700.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-2700",
+    "nature": "IDCC",
+    "num": 2700,
+    "shortTitle": "Convention collective départementale de la métallurgie de l'Oise",
+    "title": "Convention collective départementale de la métallurgie de l'Oise"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-2755.json
+++ b/data/KALICONT000005635842-2755.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-2755",
+    "nature": "IDCC",
+    "num": 2755,
+    "shortTitle": "Convention collective départementale des industries de la métallurgie de Belfort/Montbéliard",
+    "title": "Convention collective départementale des industries de la métallurgie de Belfort/Montbéliard"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-2980.json
+++ b/data/KALICONT000005635842-2980.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-2980",
+    "nature": "IDCC",
+    "num": 2980,
+    "shortTitle": "Convention collective départementale de la métallurgie de la Somme",
+    "title": "Convention collective départementale de la métallurgie de la Somme"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-2992.json
+++ b/data/KALICONT000005635842-2992.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-2992",
+    "nature": "IDCC",
+    "num": 2992,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires d'Indre-et Loire",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires d'Indre-et Loire"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-3053.json
+++ b/data/KALICONT000005635842-3053.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-3053",
+    "nature": "IDCC",
+    "num": 3053,
+    "shortTitle": "Convention collective départementale des industries de la métallurgie de Haute-Saône",
+    "title": "Convention collective départementale des industries de la métallurgie de Haute-Saône"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-714.json
+++ b/data/KALICONT000005635842-714.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-714",
+    "nature": "IDCC",
+    "num": 714,
+    "shortTitle": "Convention collective départementale des industries du travail des métaux de la Moselle (métallurgie)",
+    "title": "Convention collective départementale des industries du travail des métaux de la Moselle (métallurgie)"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-822.json
+++ b/data/KALICONT000005635842-822.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-822",
+    "nature": "IDCC",
+    "num": 822,
+    "shortTitle": "Convention collective départementale applicable aux mensuels de la métallurgie de la Savoie",
+    "title": "Convention collective départementale applicable aux mensuels de la métallurgie de la Savoie"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-827.json
+++ b/data/KALICONT000005635842-827.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-827",
+    "nature": "IDCC",
+    "num": 827,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques et connexes des Ardennes",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques et connexes des Ardennes"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-828.json
+++ b/data/KALICONT000005635842-828.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-828",
+    "nature": "IDCC",
+    "num": 828,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, connexes et similaires de la Manche",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques, connexes et similaires de la Manche"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-829.json
+++ b/data/KALICONT000005635842-829.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-829",
+    "nature": "IDCC",
+    "num": 829,
+    "shortTitle": "Convention collective départementale des industries métallurgiques et des industries connexes du Vaucluse",
+    "title": "Convention collective départementale des industries métallurgiques et des industries connexes du Vaucluse"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-836.json
+++ b/data/KALICONT000005635842-836.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-836",
+    "nature": "IDCC",
+    "num": 836,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de la Haute-Savoie",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de la Haute-Savoie"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-860.json
+++ b/data/KALICONT000005635842-860.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-860",
+    "nature": "IDCC",
+    "num": 860,
+    "shortTitle": "Convention collective départementale de la métallurgie et des industries connexes du Finistère",
+    "title": "Convention collective départementale de la métallurgie et des industries connexes du Finistère"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-863.json
+++ b/data/KALICONT000005635842-863.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-863",
+    "nature": "IDCC",
+    "num": 863,
+    "shortTitle": "Convention collective régionale des industries métallurgiques et connexes d'Ille-et-Vilaine et du Morbihan",
+    "title": "Convention collective régionale des industries métallurgiques et connexes d'Ille-et-Vilaine et du Morbihan"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-878.json
+++ b/data/KALICONT000005635842-878.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-878",
+    "nature": "IDCC",
+    "num": 878,
+    "shortTitle": "Convention collective départementale des mensuels des industries métallurgiques du Rhône",
+    "title": "Convention collective départementale des mensuels des industries métallurgiques du Rhône"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-887.json
+++ b/data/KALICONT000005635842-887.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-887",
+    "nature": "IDCC",
+    "num": 887,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques et connexes de l'Eure",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques et connexes de l'Eure"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-898.json
+++ b/data/KALICONT000005635842-898.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-898",
+    "nature": "IDCC",
+    "num": 898,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de l'Allier",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de l'Allier"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-899.json
+++ b/data/KALICONT000005635842-899.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-899",
+    "nature": "IDCC",
+    "num": 899,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques et connexes de la Marne",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques et connexes de la Marne"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-911.json
+++ b/data/KALICONT000005635842-911.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-911",
+    "nature": "IDCC",
+    "num": 911,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de Seine-et-Marne",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de Seine-et-Marne"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-914.json
+++ b/data/KALICONT000005635842-914.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-914",
+    "nature": "IDCC",
+    "num": 914,
+    "shortTitle": "Convention collective départementale des mensuels des industries métallurgiques de l'Ain",
+    "title": "Convention collective départementale des mensuels des industries métallurgiques de l'Ain"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-920.json
+++ b/data/KALICONT000005635842-920.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-920",
+    "nature": "IDCC",
+    "num": 920,
+    "shortTitle": "Convention collective départementale des industries métallurgiques électriques et connexes de la Vienne",
+    "title": "Convention collective départementale des industries métallurgiques électriques et connexes de la Vienne"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-923.json
+++ b/data/KALICONT000005635842-923.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-923",
+    "nature": "IDCC",
+    "num": 923,
+    "shortTitle": "Convention collective départementale de la métallurgie de la Charente-Maritime",
+    "title": "Convention collective départementale de la métallurgie de la Charente-Maritime"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-930.json
+++ b/data/KALICONT000005635842-930.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-930",
+    "nature": "IDCC",
+    "num": 930,
+    "shortTitle": "Convention collective départementale de la métallurgie et des industries connexes de la Sarthe",
+    "title": "Convention collective départementale de la métallurgie et des industries connexes de la Sarthe"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-934.json
+++ b/data/KALICONT000005635842-934.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-934",
+    "nature": "IDCC",
+    "num": 934,
+    "shortTitle": "Convention collective départementale des industries métallurgiques mécaniques connexes et similaires de l'Indre",
+    "title": "Convention collective départementale des industries métallurgiques mécaniques connexes et similaires de l'Indre"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-937.json
+++ b/data/KALICONT000005635842-937.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-937",
+    "nature": "IDCC",
+    "num": 937,
+    "shortTitle": "Convention collective régionale des industries métallurgiques mécaniques et connexes de la Haute-Vienne et de la Creuse",
+    "title": "Convention collective régionale des industries métallurgiques mécaniques et connexes de la Haute-Vienne et de la Creuse"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-943.json
+++ b/data/KALICONT000005635842-943.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-943",
+    "nature": "IDCC",
+    "num": 943,
+    "shortTitle": "Convention collective départementale des industries métallurgiques mécaniques et connexes du Calvados",
+    "title": "Convention collective départementale des industries métallurgiques mécaniques et connexes du Calvados"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-948.json
+++ b/data/KALICONT000005635842-948.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-948",
+    "nature": "IDCC",
+    "num": 948,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques et connexes de l'Orne",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques et connexes de l'Orne"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-965.json
+++ b/data/KALICONT000005635842-965.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-965",
+    "nature": "IDCC",
+    "num": 965,
+    "shortTitle": "Convention collective départementale des industries métallurgiques et connexes du département du Var",
+    "title": "Convention collective départementale des industries métallurgiques et connexes du département du Var"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-979.json
+++ b/data/KALICONT000005635842-979.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-979",
+    "nature": "IDCC",
+    "num": 979,
+    "shortTitle": "Convention collective locale des industries métallurgiques de l'arrondissement du Havre (Seine-Maritime)",
+    "title": "Convention collective locale des industries métallurgiques de l'arrondissement du Havre (Seine-Maritime)"
+  },
+  "children": []
+}

--- a/data/KALICONT000005635842-984.json
+++ b/data/KALICONT000005635842-984.json
@@ -1,0 +1,12 @@
+{
+  "type": "section",
+  "data": {
+    "active": true,
+    "id": "KALICONT000005635842-984",
+    "nature": "IDCC",
+    "num": 984,
+    "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques et connexes d'Eure-et-Loir",
+    "title": "Convention collective départementale des industries métallurgiques, mécaniques et connexes d'Eure-et-Loir"
+  },
+  "children": []
+}

--- a/data/index.json
+++ b/data/index.json
@@ -4331,5 +4331,581 @@
         "texte_de_base": "KALITEXT000005658612",
         "title": "Convention collective régionale des ouvriers du bâtiment de la région parisienne du 28 juin 1993. Etendue par arrêté du 9 décembre 1993 JORF 24 décembre 1993.",
         "url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635685"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-827",
+        "nature": "IDCC",
+        "num": 827,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques et connexes des Ardennes",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques et connexes des Ardennes"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-828",
+        "nature": "IDCC",
+        "num": 828,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, connexes et similaires de la Manche",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques, connexes et similaires de la Manche"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-829",
+        "nature": "IDCC",
+        "num": 829,
+        "shortTitle": "Convention collective départementale des industries métallurgiques et des industries connexes du Vaucluse",
+        "title": "Convention collective départementale des industries métallurgiques et des industries connexes du Vaucluse"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-878",
+        "nature": "IDCC",
+        "num": 878,
+        "shortTitle": "Convention collective départementale des mensuels des industries métallurgiques du Rhône",
+        "title": "Convention collective départementale des mensuels des industries métallurgiques du Rhône"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-836",
+        "nature": "IDCC",
+        "num": 836,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de la Haute-Savoie",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de la Haute-Savoie"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-914",
+        "nature": "IDCC",
+        "num": 914,
+        "shortTitle": "Convention collective départementale des mensuels des industries métallurgiques de l'Ain",
+        "title": "Convention collective départementale des mensuels des industries métallurgiques de l'Ain"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-898",
+        "nature": "IDCC",
+        "num": 898,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de l'Allier",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de l'Allier"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-920",
+        "nature": "IDCC",
+        "num": 920,
+        "shortTitle": "Convention collective départementale des industries métallurgiques électriques et connexes de la Vienne",
+        "title": "Convention collective départementale des industries métallurgiques électriques et connexes de la Vienne"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1007",
+        "nature": "IDCC",
+        "num": 1007,
+        "shortTitle": "Convention collective locale d'arrondissement des industries métallurgiques, mécaniques, connexes et similaires de la région de Thiers (Puy-de-Dôme)",
+        "title": "Convention collective locale d'arrondissement des industries métallurgiques, mécaniques, connexes et similaires de la région de Thiers (Puy-de-Dôme)"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-863",
+        "nature": "IDCC",
+        "num": 863,
+        "shortTitle": "Convention collective régionale des industries métallurgiques et connexes d'Ille-et-Vilaine et du Morbihan",
+        "title": "Convention collective régionale des industries métallurgiques et connexes d'Ille-et-Vilaine et du Morbihan"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-934",
+        "nature": "IDCC",
+        "num": 934,
+        "shortTitle": "Convention collective départementale des industries métallurgiques mécaniques connexes et similaires de l'Indre",
+        "title": "Convention collective départementale des industries métallurgiques mécaniques connexes et similaires de l'Indre"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-887",
+        "nature": "IDCC",
+        "num": 887,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques et connexes de l'Eure",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques et connexes de l'Eure"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-984",
+        "nature": "IDCC",
+        "num": 984,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques et connexes d'Eure-et-Loir",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques et connexes d'Eure-et-Loir"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-899",
+        "nature": "IDCC",
+        "num": 899,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques et connexes de la Marne",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques et connexes de la Marne"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-911",
+        "nature": "IDCC",
+        "num": 911,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de Seine-et-Marne",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de Seine-et-Marne"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-937",
+        "nature": "IDCC",
+        "num": 937,
+        "shortTitle": "Convention collective régionale des industries métallurgiques mécaniques et connexes de la Haute-Vienne et de la Creuse",
+        "title": "Convention collective régionale des industries métallurgiques mécaniques et connexes de la Haute-Vienne et de la Creuse"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-923",
+        "nature": "IDCC",
+        "num": 923,
+        "shortTitle": "Convention collective départementale de la métallurgie de la Charente-Maritime",
+        "title": "Convention collective départementale de la métallurgie de la Charente-Maritime"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-943",
+        "nature": "IDCC",
+        "num": 943,
+        "shortTitle": "Convention collective départementale des industries métallurgiques mécaniques et connexes du Calvados",
+        "title": "Convention collective départementale des industries métallurgiques mécaniques et connexes du Calvados"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-979",
+        "nature": "IDCC",
+        "num": 979,
+        "shortTitle": "Convention collective locale des industries métallurgiques de l'arrondissement du Havre (Seine-Maritime)",
+        "title": "Convention collective locale des industries métallurgiques de l'arrondissement du Havre (Seine-Maritime)"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-948",
+        "nature": "IDCC",
+        "num": 948,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques et connexes de l'Orne",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques et connexes de l'Orne"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1560",
+        "nature": "IDCC",
+        "num": 1560,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, électriques et connexes des AlpesMaritimes",
+        "title": "Convention collective départementale des industries métallurgiques, électriques et connexes des AlpesMaritimes"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-965",
+        "nature": "IDCC",
+        "num": 965,
+        "shortTitle": "Convention collective départementale des industries métallurgiques et connexes du département du Var",
+        "title": "Convention collective départementale des industries métallurgiques et connexes du département du Var"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-930",
+        "nature": "IDCC",
+        "num": 930,
+        "shortTitle": "Convention collective départementale de la métallurgie et des industries connexes de la Sarthe",
+        "title": "Convention collective départementale de la métallurgie et des industries connexes de la Sarthe"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1387",
+        "nature": "IDCC",
+        "num": 1387,
+        "shortTitle": "Convention collective locale des mensuels des industries métallurgiques des Flandres",
+        "title": "Convention collective locale des mensuels des industries métallurgiques des Flandres"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1164",
+        "nature": "IDCC",
+        "num": 1164,
+        "shortTitle": "Convention collective locale des industries métallurgiques et annexes de la région de Vimeu (Somme)",
+        "title": "Convention collective locale des industries métallurgiques et annexes de la région de Vimeu (Somme)"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1274",
+        "nature": "IDCC",
+        "num": 1274,
+        "shortTitle": "Convention collective départementale des industries métallurgiques de la Corrèze",
+        "title": "Convention collective départementale des industries métallurgiques de la Corrèze"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1353",
+        "nature": "IDCC",
+        "num": 1353,
+        "shortTitle": "Convention collective départementale des industries métallurgiques et connexes de la Dordogne",
+        "title": "Convention collective départementale des industries métallurgiques et connexes de la Dordogne"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1369",
+        "nature": "IDCC",
+        "num": 1369,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, électriques, électroniques et connexes de Loire-Atlantique",
+        "title": "Convention collective départementale des industries métallurgiques, électriques, électroniques et connexes de Loire-Atlantique"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1525",
+        "nature": "IDCC",
+        "num": 1525,
+        "shortTitle": "Convention collective locale de la métallurgie de la région dunkerquoise",
+        "title": "Convention collective locale de la métallurgie de la région dunkerquoise"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1592",
+        "nature": "IDCC",
+        "num": 1592,
+        "shortTitle": "Convention collective locale de la métallurgie du Valenciennois et du Cambrésis",
+        "title": "Convention collective locale de la métallurgie du Valenciennois et du Cambrésis"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1472",
+        "nature": "IDCC",
+        "num": 1472,
+        "shortTitle": "Convention collective départementale des industries métallurgiques du Pas-de-Calais",
+        "title": "Convention collective départementale des industries métallurgiques du Pas-de-Calais"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1572",
+        "nature": "IDCC",
+        "num": 1572,
+        "shortTitle": "Convention collective départementale de la métallurgie de la Charente",
+        "title": "Convention collective départementale de la métallurgie de la Charente"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1578",
+        "nature": "IDCC",
+        "num": 1578,
+        "shortTitle": "Convention collective départementale de la métallurgie de la Loire et de l'arrondissement d'Yssingeaux",
+        "title": "Convention collective départementale de la métallurgie de la Loire et de l'arrondissement d'Yssingeaux"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1577",
+        "nature": "IDCC",
+        "num": 1577,
+        "shortTitle": "Convention collective régionale des industries métallurgiques, électroniques et connexes de l'Hérault, de l'Aude et des Pyrénées-Orientales",
+        "title": "Convention collective régionale des industries métallurgiques, électroniques et connexes de l'Hérault, de l'Aude et des Pyrénées-Orientales"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1634",
+        "nature": "IDCC",
+        "num": 1634,
+        "shortTitle": "Convention collective départementale de la métallurgie des Côtes-d'Armor",
+        "title": "Convention collective départementale de la métallurgie des Côtes-d'Armor"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1867",
+        "nature": "IDCC",
+        "num": 1867,
+        "shortTitle": "Convention collective régionale de la métallurgie de la Drôme-Ardèche",
+        "title": "Convention collective régionale de la métallurgie de la Drôme-Ardèche"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1885",
+        "nature": "IDCC",
+        "num": 1885,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques et connexes du département de la Côte-d'Or",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques et connexes du département de la Côte-d'Or"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1627",
+        "nature": "IDCC",
+        "num": 1627,
+        "shortTitle": "Convention collective départementale du travail des industries de la métallurgie et des constructions mécaniques de Clermont-Ferrand et du Puy-de-Dôme",
+        "title": "Convention collective départementale du travail des industries de la métallurgie et des constructions mécaniques de Clermont-Ferrand et du Puy-de-Dôme"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1732",
+        "nature": "IDCC",
+        "num": 1732,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques et connexes de l'Yonne",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques et connexes de l'Yonne"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1809",
+        "nature": "IDCC",
+        "num": 1809,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, similaires et connexes du Jura",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques, similaires et connexes du Jura"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1813",
+        "nature": "IDCC",
+        "num": 1813,
+        "shortTitle": "Convention collective locale de travail des industries de la transformation des métaux de la région de Maubeuge",
+        "title": "Convention collective locale de travail des industries de la transformation des métaux de la région de Maubeuge"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1628",
+        "nature": "IDCC",
+        "num": 1628,
+        "shortTitle": "Convention collective départementale de la métallurgie des Deux-Sèvres",
+        "title": "Convention collective départementale de la métallurgie des Deux-Sèvres"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1902",
+        "nature": "IDCC",
+        "num": 1902,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, électroniques connexes et similaires du Maine-et-Loire",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, électroniques connexes et similaires du Maine-et-Loire"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-2221",
+        "nature": "IDCC",
+        "num": 2221,
+        "shortTitle": "Convention collective régionale des mensuels des industries des métaux de l'Isère et des Hautes-Alpes",
+        "title": "Convention collective régionale des mensuels des industries des métaux de l'Isère et des Hautes-Alpes"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1966",
+        "nature": "IDCC",
+        "num": 1966,
+        "shortTitle": "Convention collective départementale des industries métallurgiques du Loiret",
+        "title": "Convention collective départementale des industries métallurgiques du Loiret"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1967",
+        "nature": "IDCC",
+        "num": 1967,
+        "shortTitle": "Convention collective départementale de l'industrie des métaux du Bas-Rhin",
+        "title": "Convention collective départementale de l'industrie des métaux du Bas-Rhin"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1912",
+        "nature": "IDCC",
+        "num": 1912,
+        "shortTitle": "Convention collective départementale des industries de la métallurgie du Haut-Rhin",
+        "title": "Convention collective départementale des industries de la métallurgie du Haut-Rhin"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-2003",
+        "nature": "IDCC",
+        "num": 2003,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, électriques, électroniques et connexes du département des Vosges",
+        "title": "Convention collective départementale des industries métallurgiques, électriques, électroniques et connexes du département des Vosges"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-2126",
+        "nature": "IDCC",
+        "num": 2126,
+        "shortTitle": "Convention collective régionale de la métallurgie du Gard et de la Lozère",
+        "title": "Convention collective régionale de la métallurgie du Gard et de la Lozère"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-2615",
+        "nature": "IDCC",
+        "num": 2615,
+        "shortTitle": "Convention collective régionale de la métallurgie des Pyrénées-Atlantiques et du Seignanx",
+        "title": "Convention collective régionale de la métallurgie des Pyrénées-Atlantiques et du Seignanx"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-2489",
+        "nature": "IDCC",
+        "num": 2489,
+        "shortTitle": "Convention collective départementale des industries métallurgiques et assimilées de la Vendée",
+        "title": "Convention collective départementale des industries métallurgiques et assimilées de la Vendée"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-2266",
+        "nature": "IDCC",
+        "num": 2266,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de la Mayenne",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de la Mayenne"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-3053",
+        "nature": "IDCC",
+        "num": 3053,
+        "shortTitle": "Convention collective départementale des industries de la métallurgie de Haute-Saône",
+        "title": "Convention collective départementale des industries de la métallurgie de Haute-Saône"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-2700",
+        "nature": "IDCC",
+        "num": 2700,
+        "shortTitle": "Convention collective départementale de la métallurgie de l'Oise",
+        "title": "Convention collective départementale de la métallurgie de l'Oise"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-2980",
+        "nature": "IDCC",
+        "num": 2980,
+        "shortTitle": "Convention collective départementale de la métallurgie de la Somme",
+        "title": "Convention collective départementale de la métallurgie de la Somme"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-822",
+        "nature": "IDCC",
+        "num": 822,
+        "shortTitle": "Convention collective départementale applicable aux mensuels de la métallurgie de la Savoie",
+        "title": "Convention collective départementale applicable aux mensuels de la métallurgie de la Savoie"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-2755",
+        "nature": "IDCC",
+        "num": 2755,
+        "shortTitle": "Convention collective départementale des industries de la métallurgie de Belfort/Montbéliard",
+        "title": "Convention collective départementale des industries de la métallurgie de Belfort/Montbéliard"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1564",
+        "nature": "IDCC",
+        "num": 1564,
+        "shortTitle": "Convention collective départementale des industries de la métallurgie de Saône-et-Loire",
+        "title": "Convention collective départementale des industries de la métallurgie de Saône-et-Loire"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-2630",
+        "nature": "IDCC",
+        "num": 2630,
+        "shortTitle": "Convention collective régionale des industries métallurgiques des Bouches-du-Rhône et Alpes-de-HauteProvence",
+        "title": "Convention collective régionale des industries métallurgiques des Bouches-du-Rhône et Alpes-de-HauteProvence"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1375",
+        "nature": "IDCC",
+        "num": 1375,
+        "shortTitle": "Convention collective Métallurgie Doubs",
+        "title": "Convention collective Métallurgie Doubs"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1159",
+        "nature": "IDCC",
+        "num": 1159,
+        "shortTitle": "Convention collective départementale de la métallurgie de la Nièvre",
+        "title": "Convention collective départementale de la métallurgie de la Nièvre"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-860",
+        "nature": "IDCC",
+        "num": 860,
+        "shortTitle": "Convention collective départementale de la métallurgie et des industries connexes du Finistère",
+        "title": "Convention collective départementale de la métallurgie et des industries connexes du Finistère"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-2992",
+        "nature": "IDCC",
+        "num": 2992,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires d'Indre-et Loire",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires d'Indre-et Loire"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1576",
+        "nature": "IDCC",
+        "num": 1576,
+        "shortTitle": "Convention collective départementale de travail des industries métallurgiques, mécaniques, électriques, électroniques, connexes et similaires du département du Cher",
+        "title": "Convention collective départementale de travail des industries métallurgiques, mécaniques, électriques, électroniques, connexes et similaires du département du Cher"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-714",
+        "nature": "IDCC",
+        "num": 714,
+        "shortTitle": "Convention collective départementale des industries du travail des métaux de la Moselle (métallurgie)",
+        "title": "Convention collective départementale des industries du travail des métaux de la Moselle (métallurgie)"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1315",
+        "nature": "IDCC",
+        "num": 1315,
+        "shortTitle": "Convention collective régionale des industries métallurgiques, mécaniques et connexes de la Haute-Marne et de la Meuse",
+        "title": "Convention collective régionale des industries métallurgiques, mécaniques et connexes de la Haute-Marne et de la Meuse"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1365",
+        "nature": "IDCC",
+        "num": 1365,
+        "shortTitle": "Convention collective départementale de travail des industries de transformation des métaux de Meurthe-et-Moselle (métallurgie)",
+        "title": "Convention collective départementale de travail des industries de transformation des métaux de Meurthe-et-Moselle (métallurgie)"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-2294",
+        "nature": "IDCC",
+        "num": 2294,
+        "shortTitle": "Convention collective départementale des industries et métiers de la métallurgie de l'Aube",
+        "title": "Convention collective départementale des industries et métiers de la métallurgie de l'Aube"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1059",
+        "nature": "IDCC",
+        "num": 1059,
+        "shortTitle": "Convention collective régionale des industries métallurgiques, électriques, électroniques et connexes de MidiPyrénées (Ariège, Aveyron, Gers, Haute-Garonne, Tarn, Tarn-et-Garonne, Lot, Aude convention du 1er avril 1980)",
+        "title": "Convention collective régionale des industries métallurgiques, électriques, électroniques et connexes de MidiPyrénées (Ariège, Aveyron, Gers, Haute-Garonne, Tarn, Tarn-et-Garonne, Lot, Aude convention du 1er avril 1980)"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1960",
+        "nature": "IDCC",
+        "num": 1960,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques et connexes du Lot-et-Garonne",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques et connexes du Lot-et-Garonne"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1604",
+        "nature": "IDCC",
+        "num": 1604,
+        "shortTitle": "Convention collective métallurgie Rouen Dieppe (Seine-Maritime)",
+        "title": "Convention collective métallurgie Rouen Dieppe (Seine-Maritime)"
+    },
+    {
+        "active": true,
+        "id": "KALICONT000005635842-1626",
+        "nature": "IDCC",
+        "num": 1626,
+        "shortTitle": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, électrocéramiques et connexes des Hautes-Pyrénées",
+        "title": "Convention collective départementale des industries métallurgiques, mécaniques, électriques, électrocéramiques et connexes des Hautes-Pyrénées"
     }
 ]

--- a/scripts/fetch-ccns.js
+++ b/scripts/fetch-ccns.js
@@ -18,7 +18,7 @@ const checkCcn = ccn => {
 //for each convention, fetch convention conteneur, populate conteneur texts, and ouput to JSON file.
 const fetchAllConventions = () =>
   pMap(
-    conventions,
+    conventions.filter(convention => !!convention.url),
     convention => {
       const filePath = path.join(__dirname, `../data/${convention.id}.json`);
       console.log(`fetch ${convention.id}`);


### PR DESCRIPTION
Ajout de 72 conventions (issues de la base des contribs)

certains champs ne sont pas présents comme `etat` ou `url` et le contenu des conventions est vide. l'id a été généré à partir de l'id de la CC mère puis du numéro IDCC régional

ex: `KALICONT000005635842-1007`

IDCC | Nom
------|-------
827 | Convention collective départementale des industries métallurgiques, mécaniques et connexes des Ardennes
828 | Convention collective départementale des industries métallurgiques, mécaniques, connexes et similaires de la Manche
829 | Convention collective départementale des industries métallurgiques et des industries connexes du Vaucluse
878 | Convention collective départementale des mensuels des industries métallurgiques du Rhône
836 | Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de la Haute-Savoie
914 | Convention collective départementale des mensuels des industries métallurgiques de l'Ain
898 | Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de l'Allier
920 | Convention collective départementale des industries métallurgiques électriques et connexes de la Vienne
1007 | Convention collective locale d'arrondissement des industries métallurgiques, mécaniques, connexes et similaires de la région de Thiers (Puy-de-Dôme)
863 | Convention collective régionale des industries métallurgiques et connexes d'Ille-et-Vilaine et du Morbihan
934 | Convention collective départementale des industries métallurgiques mécaniques connexes et similaires de l'Indre
887 | Convention collective départementale des industries métallurgiques, mécaniques, électriques et connexes de l'Eure
984 | Convention collective départementale des industries métallurgiques, mécaniques et connexes d'Eure-et-Loir
899 | Convention collective départementale des industries métallurgiques, mécaniques et connexes de la Marne
911 | Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de Seine-et-Marne
937 | Convention collective régionale des industries métallurgiques mécaniques et connexes de la Haute-Vienne et de la Creuse
923 | Convention collective départementale de la métallurgie de la Charente-Maritime
943 | Convention collective départementale des industries métallurgiques mécaniques et connexes du Calvados
979 | Convention collective locale des industries métallurgiques de l'arrondissement du Havre (Seine-Maritime)
948 | Convention collective départementale des industries métallurgiques, mécaniques et connexes de l'Orne
1560 | Convention collective départementale des industries métallurgiques, électriques et connexes des AlpesMaritimes
965 | Convention collective départementale des industries métallurgiques et connexes du département du Var
930 | Convention collective départementale de la métallurgie et des industries connexes de la Sarthe
1387 | Convention collective locale des mensuels des industries métallurgiques des Flandres
1164 | Convention collective locale des industries métallurgiques et annexes de la région de Vimeu (Somme)
1274 | Convention collective départementale des industries métallurgiques de la Corrèze
1353 | Convention collective départementale des industries métallurgiques et connexes de la Dordogne
1369 | Convention collective départementale des industries métallurgiques, électriques, électroniques et connexes de Loire-Atlantique
1525 | Convention collective locale de la métallurgie de la région dunkerquoise
1592 | Convention collective locale de la métallurgie du Valenciennois et du Cambrésis
1472 | Convention collective départementale des industries métallurgiques du Pas-de-Calais
1572 | Convention collective départementale de la métallurgie de la Charente
1578 | Convention collective départementale de la métallurgie de la Loire et de l'arrondissement d'Yssingeaux
1577 | Convention collective régionale des industries métallurgiques, électroniques et connexes de l'Hérault, de l'Aude et des Pyrénées-Orientales
1634 | Convention collective départementale de la métallurgie des Côtes-d'Armor
1867 | Convention collective régionale de la métallurgie de la Drôme-Ardèche
1885 | Convention collective départementale des industries métallurgiques, mécaniques, électriques et connexes du département de la Côte-d'Or
1627 | Convention collective départementale du travail des industries de la métallurgie et des constructions mécaniques de Clermont-Ferrand et du Puy-de-Dôme
1732 | Convention collective départementale des industries métallurgiques, mécaniques, électriques et connexes de l'Yonne
1809 | Convention collective départementale des industries métallurgiques, mécaniques, similaires et connexes du Jura
1813 | Convention collective locale de travail des industries de la transformation des métaux de la région de Maubeuge
1628 | Convention collective départementale de la métallurgie des Deux-Sèvres
1902 | Convention collective départementale des industries métallurgiques, mécaniques, électriques, électroniques connexes et similaires du Maine-et-Loire
2221 | Convention collective régionale des mensuels des industries des métaux de l'Isère et des Hautes-Alpes
1966 | Convention collective départementale des industries métallurgiques du Loiret
1967 | Convention collective départementale de l'industrie des métaux du Bas-Rhin
1912 | Convention collective départementale des industries de la métallurgie du Haut-Rhin
2003 | Convention collective départementale des industries métallurgiques, électriques, électroniques et connexes du département des Vosges
2126 | Convention collective régionale de la métallurgie du Gard et de la Lozère
2615 | Convention collective régionale de la métallurgie des Pyrénées-Atlantiques et du Seignanx
2489 | Convention collective départementale des industries métallurgiques et assimilées de la Vendée
2266 | Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires de la Mayenne
3053 | Convention collective départementale des industries de la métallurgie de Haute-Saône
2700 | Convention collective départementale de la métallurgie de l'Oise
2980 | Convention collective départementale de la métallurgie de la Somme
822 | Convention collective départementale applicable aux mensuels de la métallurgie de la Savoie
2755 | Convention collective départementale des industries de la métallurgie de Belfort/Montbéliard
1564 | Convention collective départementale des industries de la métallurgie de Saône-et-Loire
2630 | Convention collective régionale des industries métallurgiques des Bouches-du-Rhône et Alpes-de-HauteProvence
1375 | Convention collective Métallurgie Doubs
1159 | Convention collective départementale de la métallurgie de la Nièvre
860 | Convention collective départementale de la métallurgie et des industries connexes du Finistère
2992 | Convention collective départementale des industries métallurgiques, mécaniques, électriques, connexes et similaires d'Indre-et Loire
1576 | Convention collective départementale de travail des industries métallurgiques, mécaniques, électriques, électroniques, connexes et similaires du département du Cher
714 | Convention collective départementale des industries du travail des métaux de la Moselle (métallurgie)
1315 | Convention collective régionale des industries métallurgiques, mécaniques et connexes de la Haute-Marne et de la Meuse
1365 | Convention collective départementale de travail des industries de transformation des métaux de Meurthe-et-Moselle (métallurgie)
2294 | Convention collective départementale des industries et métiers de la métallurgie de l'Aube
1059 | Convention collective régionale des industries métallurgiques, électriques, électroniques et connexes de MidiPyrénées (Ariège, Aveyron, Gers, Haute-Garonne, Tarn, Tarn-et-Garonne, Lot, Aude convention du 1er avril 1980)
1960 | Convention collective départementale des industries métallurgiques, mécaniques et connexes du Lot-et-Garonne
1604 | Convention collective métallurgie Rouen Dieppe (Seine-Maritime)
1626 | Convention collective départementale des industries métallurgiques, mécaniques, électriques, électrocéramiques et connexes des Hautes-Pyrénées
