### PR TITLE
fix(scripts): handle empty text returned by api

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "prompt": "1.0.0",
     "semantic-release": "17.1.2",
     "typescript": "3.9.7",
-    "unist-util-map": "2.0.1",
-    "unist-util-remove": "2.0.0"
+    "unist-util-filter": "^2.0.3",
+    "unist-util-map": "2.0.1"
   },
   "engines": {
     "node": ">= 10"

--- a/scripts/fetch.js
+++ b/scripts/fetch.js
@@ -4,8 +4,8 @@ import pPipe from "p-pipe";
 import Queue from "p-queue";
 import retry from "p-retry";
 import path from "path";
-import map from "unist-util-map";
 import filter from "unist-util-filter";
+import map from "unist-util-map";
 import { promisify } from "util";
 
 import { getAgreements } from "../src";

--- a/scripts/fetch.js
+++ b/scripts/fetch.js
@@ -5,7 +5,7 @@ import Queue from "p-queue";
 import retry from "p-retry";
 import path from "path";
 import map from "unist-util-map";
-import remove from "unist-util-remove";
+import filter from "unist-util-filter";
 import { promisify } from "util";
 
 import { getAgreements } from "../src";
@@ -74,7 +74,13 @@ async function fetchAdditionalText(container) {
 }
 
 function cleanAst(tree) {
-  remove(tree, node => isValidSection(node.data));
+  const cleanedTree = filter(tree, node => {
+    return (
+      node.type !== "section" ||
+      (["article", "section"].includes(node.type) && (node.data.etat || "").startsWith("VIGUEUR"))
+    );
+  });
+
   const keys = [
     "cid",
     "num",
@@ -92,7 +98,7 @@ function cleanAst(tree) {
     "lstLienModification",
   ];
 
-  return map(tree, ({ type, data: rawData, children }) => {
+  return map(cleanedTree, ({ type, data: rawData, children }) => {
     const data = keys.reduce((data, key) => {
       if (rawData[key] !== null || rawData[key]) {
         data[key] = rawData[key];

--- a/scripts/libs/__tests__/astify.test.js
+++ b/scripts/libs/__tests__/astify.test.js
@@ -65,6 +65,6 @@ describe("isValidSection", () => {
     expect(isValidSection({ etat: "VIGUEUR_NON_ETEN" })).toEqual(true);
   });
   test("should include section without etat", () => {
-    expect(isValidSection({})).toEqual(true);
+    expect(isValidSection({ jurisState: "VIGUEUR" })).toEqual(true);
   });
 });

--- a/scripts/libs/astify.js
+++ b/scripts/libs/astify.js
@@ -39,7 +39,9 @@ const astify = (node, depth = 0) => ({
 
 const numify = id => parseInt(id.replace(/^KALI(ARTI|SCTA|TEXT)/, ""));
 
-export const isValidSection = node => !node.etat || node.etat.startsWith("VIGUEUR");
+export const isValidSection = node => {
+  return (node.etat || node.jurisState || "").startsWith("VIGUEUR");
+};
 
 // the API returns all the version of a given article. we pick the latest one
 export const latestVersionFilter = (currentArticle, _, articles) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8563,6 +8563,13 @@ unique-string@^2.0.0:
   dependencies:
     crypto-random-string "^2.0.0"
 
+unist-util-filter@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/unist-util-filter/-/unist-util-filter-2.0.3.tgz#558cf866016f0e7ade1e30ef190abf253111dd39"
+  integrity sha512-8k6Jl/KLFqIRTHydJlHh6+uFgqYHq66pV75pZgr1JwfyFSjbWb12yfb0yitW/0TbHXjr9U4G9BQpOvMANB+ExA==
+  dependencies:
+    unist-util-is "^4.0.0"
+
 unist-util-find@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/unist-util-find/-/unist-util-find-1.0.1.tgz#1062bbb6928c7a97c6adc89b53745d4c46c222a2"
@@ -8610,13 +8617,6 @@ unist-util-remove-position@^1.0.0:
   integrity sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==
   dependencies:
     unist-util-visit "^1.1.0"
-
-unist-util-remove@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-remove/-/unist-util-remove-2.0.0.tgz#32c2ad5578802f2ca62ab808173d505b2c898488"
-  integrity sha512-HwwWyNHKkeg/eXRnE11IpzY8JT55JNM1YCwwU9YNCnfzk6s8GhPXrVBBZWiwLeATJbI7euvoGSzcy9M29UeW3g==
-  dependencies:
-    unist-util-is "^4.0.0"
 
 unist-util-visit-parents@^2.0.0:
   version "2.1.2"


### PR DESCRIPTION
lors de la récupération de la CC 1496, l'api renvoi un texte attaché vide 
<details>
<summary>KALITEXT000042085809</summary>

```
{
  "executionTime": 0,
  "dereferenced": true,
  "id": null,
  "idConteneur": null,
  "cid": null,
  "title": null,
  "nor": null,
  "eli": null,
  "alias": null,
  "jorfText": null,
  "jurisState": null,
  "visa": null,
  "modifDate": null,
  "jurisDate": null,
  "dateDebutVersion": null,
  "dateFinVersion": null,
  "signers": null,
  "prepWork": null,
  "dateParution": null,
  "numParution": null,
  "notice": null,
  "nota": null,
  "inap": null,
  "textNumber": null,
  "textAbroge": null,
  "etat": null,
  "dossiersLegislatifs": [],
  "nature": null,
  "resume": null,
  "rectificatif": null,
  "motsCles": [],
  "liens": [],
  "observations": null,
  "sections": [],
  "articles": [],
  "fileName": null,
  "fileSize": null,
  "filePath": null,
  "signataires": null,
  "numeroBo": null,
  "originePubli": null,
  "codesNomenclature": [],
  "typeTexte": null,
  "conditionDiffere": null,
  "conteneurs": [],
  "libelleExtension": null,
  "libelleElargissement": null
}

```
</details>

il semblerai que le `  remove(tree, node => isValidSection(node.data));` ligne 77 ne soit pas super efficace :/

close #147